### PR TITLE
Workaround, issue 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "laravel/framework": "4.*",
+        "laravel/framework": "4.1.*",
         "moltin/cart": "dev-master"
     },
     "require-dev": {

--- a/src/Moltin/Cart/CartServiceProvider.php
+++ b/src/Moltin/Cart/CartServiceProvider.php
@@ -24,17 +24,21 @@ namespace Moltin\Cart;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Config;
 
-use Moltin\Cart\Storage\LaravelSession as SessionStore;
-use Moltin\Cart\Storage\LaravelCache as CacheStore;
-use Moltin\Cart\Identifier\Cookie as CookieIdentifier;
+use Moltin\Cart\Storage\Session as SessionPhPStore;
+use Moltin\Cart\LaravelStorage\LaravelSession as SessionStore;
+use Moltin\Cart\LaravelStorage\LaravelCache as CacheStore;
 use Moltin\Cart\Identifier\RequestCookie as CookieRequestIdentifier;
+use Moltin\Cart\Identifier\Cookie as CookieIdentifier;
 
 class CartServiceProvider extends ServiceProvider
 {
     private function getStorageService()
     {
-        switch(Config::get('moltincart.storage', 'session'))
+        switch(Config::get('moltincart.storage', 'phpsession'))
         {
+            case 'phpsession':
+                return new SessionPhPStore;
+                break;
             case 'cache':
                 return new CacheStore;
                 break;

--- a/src/Moltin/Cart/Identifier/RequestCookie.php
+++ b/src/Moltin/Cart/Identifier/RequestCookie.php
@@ -4,7 +4,7 @@
  * @package Moltin\Cart\Storage
  * @author Theo den Hollander <theo@hollandware.com>
  */
-use Illuminate\Support\Facades\Cache;
+
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Input;
 

--- a/src/Moltin/Cart/LaravelStorage/LaravelSession.php
+++ b/src/Moltin/Cart/LaravelStorage/LaravelSession.php
@@ -1,42 +1,43 @@
-<?php namespace Moltin\Cart\Storage;
+<?php
+
 /**
- * Class LaravelCache
- * @package Moltin\Cart\Storage
- * @author Theo den Hollander <theo@hollandware.com>
+ * This file is part of Moltin Cart, a PHP package to handle
+ * your shopping basket.
+ *
+ * Copyright (c) 2013 Moltin Ltd.
+ * http://github.com/moltin/cart
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package moltin/cart
+ * @author Chris Harvey <chris@molt.in>
+ * @copyright 2013 Moltin Ltd.
+ * @version dev
+ * @link http://github.com/moltin/cart
+ *
  */
 
+namespace Moltin\Cart\LaravelStorage;
+
 use Moltin\Cart\Item;
-use Moltin\Cart\Storage;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Cache as LaravelCacheStorage;
+use Illuminate\Support\Facades\Session;
 
-class LaravelCache implements \Moltin\Cart\StorageInterface
+class LaravelSession implements \Moltin\Cart\StorageInterface
 {
-    private $cachePrefix;
-
     protected $identifier;
-
     protected static $cart = array();
 
-
-    public function __construct()
+    public function restore()
     {
-        $this->cachePrefix = Config::get('moltincart.cache_prefix', 'session');
-    }
-
-    /**
-     * @param $identifier
-     */
-    public function restore($identifier)
-    {
-        $carts = LaravelCacheStorage::get($this->cachePrefix . $identifier);
+        $carts = Session::get('cart');
 
         if ($carts) static::$cart = $carts;
     }
 
     /**
      * Add or update an item in the cart
-     *
+     * 
      * @param  Item   $item The item to insert or update
      * @return void
      */
@@ -49,8 +50,7 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
     /**
      * Retrieve the cart data
-     *
-     * @param bool $asArray
+     * 
      * @return array
      */
     public function &data($asArray = false)
@@ -70,9 +70,8 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
     /**
      * Check if the item exists in the cart
-     *
-     * @param $identifier
-     * @internal param mixed $id
+     * 
+     * @param  mixed  $id
      * @return boolean
      */
     public function has($identifier)
@@ -88,7 +87,7 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
     /**
      * Get a single cart item by id
-     *
+     * 
      * @param  mixed $id The item id
      * @return Item  The item class
      */
@@ -105,7 +104,7 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
     /**
      * Returns the first occurance of an item with a given id
-     *
+     * 
      * @param  string $id The item id
      * @return Item       Item object
      */
@@ -119,10 +118,10 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
         return false;
     }
-
+    
     /**
      * Remove an item from the cart
-     *
+     * 
      * @param  mixed $id
      * @return void
      */
@@ -135,7 +134,7 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
     /**
      * Destroy the cart
-     *
+     * 
      * @return void
      */
     public function destroy()
@@ -147,7 +146,7 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
     /**
      * Set the cart identifier
-     *
+     * 
      * @param string $identifier
      */
     public function setIdentifier($id)
@@ -163,8 +162,8 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
 
     /**
      * Return the current cart identifier
-     *
-     * @return void
+     * 
+     * @return string
      */
     public function getIdentifier()
     {
@@ -175,16 +174,6 @@ class LaravelCache implements \Moltin\Cart\StorageInterface
     {
         $data = static::$cart;
 
-        $expires = Config::get('moltincart.cache_expire', 60);
-        $cacheID = $this->cachePrefix . $this->id;
-
-        if($expires == -1)
-        {
-            LaravelCacheStorage::forever($cacheID, $data);
-        }
-        else
-        {
-            LaravelCacheStorage::put($cacheID, $data, $expires);
-        }
+        Session::put('cart', $data);
     }
 }


### PR DESCRIPTION
https://github.com/moltin/laravel-cart/issues/12
This issue is still open, workaround:
LaravelSession.php needs an release-update needed for Laravel 4.1. With this fix the php session will be used instead of the laravel session. 
