### PR TITLE
Laravel 5.2 + New Session Store Option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "laravel/framework": "~5.0",
+        "laravel/framework": "5.2.*",
         "moltin/cart": "dev-master"
     },
     "require-dev": {

--- a/src/Moltin/Cart/CartServiceProvider.php
+++ b/src/Moltin/Cart/CartServiceProvider.php
@@ -25,6 +25,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Config;
 
 use Moltin\Cart\Storage\LaravelSession as SessionStore;
+use Moltin\Cart\Storage\Session as MoltinSessionStore;
 use Moltin\Cart\Storage\LaravelCache as CacheStore;
 use Moltin\Cart\Storage\LaravelFile as FileStore;
 use Moltin\Cart\Identifier\Cookie as CookieIdentifier;
@@ -38,6 +39,10 @@ class CartServiceProvider extends ServiceProvider
         switch ($class) {
             case 'session':
                 return new SessionStore;
+            break;
+            
+            case 'moltinSession':
+                return new MoltinSessionStore;
             break;
 
             case 'cache':


### PR DESCRIPTION
Updated dependency requirements for Laravel 5.2 and added another Session Store to allow the use of PHP Sessions as the Laravel Sessions were flakey at times.